### PR TITLE
Switching to the mtlynch copy of the repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,9 +99,8 @@ ARG MEDIAGOBLIN_DB_PATH="${MEDIAGOBLIN_HOME_DIR}/mediagoblin.db"
 USER "$MEDIAGOBLIN_USER"
 WORKDIR "$APP_ROOT"
 
-ARG MEDIAGOBLIN_REPO="https://git.savannah.gnu.org/git/mediagoblin.git"
-# Check out a known-working commit from 2019-09-20
-ARG MEDIAGOBLIN_BRANCH="e34916"
+ARG MEDIAGOBLIN_REPO="https://github.com/mtlynch/mediagoblin.git"
+ARG MEDIAGOBLIN_BRANCH="2020-03-26"
 
 RUN set -xe && \
     git clone "$MEDIAGOBLIN_REPO" . && \

--- a/build
+++ b/build
@@ -26,7 +26,7 @@ docker run \
   "$IMAGE_NAME"
 
 # Give the container a little time to start up.
-sleep 10
+sleep 15
 
 curl \
   --retry 15 \


### PR DESCRIPTION
The official repo no longer builds due to Python packages changing out from under us, but the mtlynch repo has explicit version dependencies, so it should be less flaky.

Also increasing the sleep time before making requests because it seems to have gotten slower to wake up.