### PR TITLE
Removing flup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ bin/gmg dbupdate
   bin/gmg makeadmin "$MEDIAGOBLIN_ADMIN_USER"
 } || true
 
-./lazyserver.sh --server-name=broadcast
+./lazyserver.sh --server-name=main


### PR DESCRIPTION
It was used for FastCGI, but it only worked with Python2, so it no longer provides any benefit.