### PR TITLE
Adding compatiblity for user-defined config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,11 @@ EXPOSE 6543
 ENV MEDIAGOBLIN_ADMIN_USER admin
 ENV MEDIAGOBLIN_ADMIN_PASS admin
 ENV MEDIAGOBLIN_ADMIN_EMAIL some@where.com
+ENV MEDIAGOBLIN_USER "$MEDIAGOBLIN_USER"
+ENV MEDIAGOBLIN_GROUP "$MEDIAGOBLIN_GROUP"
+ENV MEDIAGOBLIN_HOME_DIR "$MEDIAGOBLIN_HOME_DIR"
 
-COPY entrypoint.sh /entrypoint.sh
-USER "$MEDIAGOBLIN_USER"
-CMD ["/entrypoint.sh"]
+COPY entrypoint.sh entrypoint.sh
+COPY init-mediagoblin.sh init-mediagoblin.sh
+COPY user-dev-workaround.sh user-dev-workaround.sh
+CMD ["./entrypoint.sh"]

--- a/init-mediagoblin.sh
+++ b/init-mediagoblin.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -uxe
+
+bin/gmg dbupdate
+
+# Ignore failure to add admin user because they may already exist.
+{
+  bin/gmg adduser \
+    --username "$MEDIAGOBLIN_ADMIN_USER" \
+    --password "$MEDIAGOBLIN_ADMIN_PASS" \
+    --email "$MEDIAGOBLIN_ADMIN_EMAIL" && \
+  bin/gmg makeadmin "$MEDIAGOBLIN_ADMIN_USER"
+} || true
+
+# Create a default mediagoblin.ini if none has been specified.
+if [[ ! -f mediagoblin.ini ]]
+then
+  echo 'Generating default mediagoblin.ini...'
+  cp mediagoblin.example.ini mediagoblin.ini
+  echo '[[mediagoblin.media_types.audio]]' >> mediagoblin.ini
+  echo '[[mediagoblin.media_types.video]]' >> mediagoblin.ini
+fi

--- a/user-dev-workaround.sh
+++ b/user-dev-workaround.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -uxe
+
+# Workaround because MediaGoblin doesn't fully respect data_basedir in the
+# mediagoblin.ini.
+#
+# When data_basedir is defined in mediagoblin.ini, MediaGoblin writes uploaded
+# files to that location, but when it tries to serve files, it still looks for
+# them in ./user_dev/media/public.
+#
+# As a workaround, create a symlink from the incorrect path to the correct
+# path.
+
+CORRECT_SERVING_DIR="${MEDIAGOBLIN_HOME_DIR}/media/public"
+INCORRECT_SERVING_DIR="./user_dev/media/public"
+
+mkdir --parents "$CORRECT_SERVING_DIR"
+mkdir --parents $(dirname "$INCORRECT_SERVING_DIR")
+ln -s "$CORRECT_SERVING_DIR" "$INCORRECT_SERVING_DIR"


### PR DESCRIPTION
Needed a workaround for a bug in how MediaGoblin handles user_dev.